### PR TITLE
Trying to load a classes in the unnamed package causes an exception

### DIFF
--- a/JCL2/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -261,7 +261,8 @@ public class JarClassLoader extends AbstractClassLoader {
              * Preserve package name.
              */
             if (result.getPackage() == null) {
-                String packageName = className.substring( 0, className.lastIndexOf( '.' ) );
+                int lastDotIndex = className.lastIndexOf( '.' );
+                String packageName = (lastDotIndex >= 0) ? className.substring( 0, lastDotIndex) : "";
                 definePackage( packageName, null, null, null, null, null, null, null );
             }
 


### PR DESCRIPTION
If the class is in the unnamed package, the index of the last dot is -1, which causes `substring` to throw a `StringIndexOutOfBoundsException`.

Here is a patch that fixes the problem.
