### PR TITLE
Add basic support for findResources method.

### DIFF
--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/AbstractClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/AbstractClassLoader.java
@@ -26,10 +26,12 @@
 
 package org.xeustechnologies.jcl;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -166,6 +168,34 @@ public abstract class AbstractClassLoader extends ClassLoader {
 		return url;
 
 	}
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        if (name == null || name.trim().equals(""))
+            return null;
+
+        Collections.sort(loaders);
+
+        Enumeration<URL> url = null;
+
+        // Check osgi boot delegation
+        if (osgiBootLoader.isEnabled()) {
+            url = osgiBootLoader.findResources(name);
+        }
+
+        if (url == null || !url.hasMoreElements()) {
+            for (ProxyClassLoader l : loaders) {
+                if (l.isEnabled()) {
+                    url = l.findResources(name);
+                    if (url != null)
+                        break;
+                }
+            }
+        }
+
+        return url;
+
+    }
 
 	/**
 	 * Overrides the getResourceAsStream method to load non-class resources from

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/ClasspathResources.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/ClasspathResources.java
@@ -91,7 +91,7 @@ public class ClasspathResources extends JarResources {
                 if (logger.isLoggable( Level.FINEST ))
                     logger.finest( "Loading resource: " + entryName );
 
-                jarEntryContents.put( entryName, content );
+                jarEntryContents.put( entryName, new JarResource(content) );
             }
         } catch (IOException e) {
             throw new JclException( e );
@@ -144,7 +144,7 @@ public class ClasspathResources extends JarResources {
             if (logger.isLoggable( Level.FINEST ))
                 logger.finest( "Loading remote resource." );
 
-            jarEntryContents.put( url.toString(), content );
+            jarEntryContents.put( url.toString(), new JarResource(content) );
         } catch (IOException e) {
             throw new JclException( e );
         } finally {
@@ -195,7 +195,7 @@ public class ClasspathResources extends JarResources {
                 if (logger.isLoggable( Level.FINEST ))
                     logger.finest( "Loading class: " + entryName );
 
-                jarEntryContents.put( entryName, content );
+                jarEntryContents.put( entryName, new JarResource(content) );
             }
         } catch (IOException e) {
             throw new JclException( e );

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -166,7 +166,7 @@ public class JarClassLoader extends AbstractClassLoader {
      * @param className
      * @return byte[]
      */
-    protected byte[] loadClassBytes(String className) {
+    protected JarResource loadClassBytes(String className) {
         className = formatClassName( className );
 
         return classpathResources.getResource( className );
@@ -237,7 +237,6 @@ public class JarClassLoader extends AbstractClassLoader {
         @Override
         public Class loadClass(String className, boolean resolveIt) {
             Class result = null;
-            byte[] classBytes;
 
             result = classes.get( className );
             if (result != null) {
@@ -246,12 +245,12 @@ public class JarClassLoader extends AbstractClassLoader {
                 return result;
             }
 
-            classBytes = loadClassBytes( className );
+            JarResource classBytes = loadClassBytes( className );
             if (classBytes == null) {
                 return null;
             }
 
-            result = defineClass( className, classBytes, 0, classBytes.length );
+            result = defineClass( className, classBytes.getContent(), 0, classBytes.getContent().length,classBytes.getProtectionDomain() );
 
             if (result == null) {
                 return null;
@@ -277,12 +276,12 @@ public class JarClassLoader extends AbstractClassLoader {
 
         @Override
         public InputStream loadResource(String name) {
-            byte[] arr = classpathResources.getResource( name );
-            if (arr != null) {
+            JarResource resource = classpathResources.getResource( name );
+            if (resource != null) {
                 if (logger.isLoggable( Level.FINEST ))
                     logger.finest( "Returning newly loaded resource " + name );
 
-                return new ByteArrayInputStream( arr );
+                return new ByteArrayInputStream( resource.getContent() );
             }
 
             return null;
@@ -310,14 +309,14 @@ public class JarClassLoader extends AbstractClassLoader {
         this.classNameReplacementChar = classNameReplacementChar;
     }
 
-    /**
-     * Returns all loaded classes and resources
-     * 
-     * @return Map
-     */
-    public Map<String, byte[]> getLoadedResources() {
-        return classpathResources.getResources();
-    }
+//    /**
+//     * Returns all loaded classes and resources
+//     *
+//     * @return Map
+//     */
+//    public Map<String, byte[]> getLoadedResources() {
+//        return classpathResources.getResources();
+//    }
 
     /**
      * @return Local JCL ProxyClassLoader

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarResource.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarResource.java
@@ -1,0 +1,31 @@
+package org.xeustechnologies.jcl;
+
+import java.security.ProtectionDomain;
+
+/**
+ * Represents class/resource loaded by JarClassLoader
+ */
+public class JarResource {
+
+    private byte[] content;
+
+    //can be null
+    private ProtectionDomain protectionDomain;
+
+    public JarResource(byte[] content, ProtectionDomain protectionDomain) {
+        this.content = content;
+        this.protectionDomain = protectionDomain;
+    }
+
+    public JarResource(byte[] content) {
+        this.content = content;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public ProtectionDomain getProtectionDomain() {
+        return protectionDomain;
+    }
+}

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/ProxyClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/ProxyClassLoader.java
@@ -28,6 +28,8 @@ package org.xeustechnologies.jcl;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Enumeration;
+import java.util.Vector;
 
 /**
  * @author Kamran Zafar
@@ -76,6 +78,15 @@ public abstract class ProxyClassLoader implements Comparable<ProxyClassLoader> {
      * @return InputStream
      */
     public abstract URL findResource(String name);
+
+    public  Enumeration<URL> findResources(String name){
+        Vector<URL> v = new Vector<URL>();
+        URL r = findResource(name);
+        if(r!=null){
+             v.add(r);
+        }
+        return v.elements();
+    }
 
     public boolean isEnabled() {
         return enabled;


### PR DESCRIPTION
Hello,
i needed at least basic support for find resources method. This is used by spring during evaluation of classpath*: resources. This implementation works only by returning single resource which is sufficient for my case. 
