### PR TITLE
JarClassloader reports incorrect URLs for resources.

### DIFF
--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/ClasspathResources.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/ClasspathResources.java
@@ -90,8 +90,11 @@ public class ClasspathResources extends JarResources {
 
                 if (logger.isLoggable( Level.FINEST ))
                     logger.finest( "Loading resource: " + entryName );
-
-                jarEntryContents.put( entryName, content );
+                
+                JclJarEntry entry = new JclJarEntry();
+                entry.setBaseUrl(resource);
+                entry.setResourceBytes(content);
+                jarEntryContents.put( entryName, entry );
             }
         } catch (IOException e) {
             throw new JclException( e );
@@ -143,8 +146,10 @@ public class ClasspathResources extends JarResources {
 
             if (logger.isLoggable( Level.FINEST ))
                 logger.finest( "Loading remote resource." );
-
-            jarEntryContents.put( url.toString(), content );
+            
+            JclJarEntry entry = new JclJarEntry();
+            entry.setResourceBytes(content);
+            jarEntryContents.put( url.toString(), entry );            
         } catch (IOException e) {
             throw new JclException( e );
         } finally {
@@ -194,8 +199,10 @@ public class ClasspathResources extends JarResources {
 
                 if (logger.isLoggable( Level.FINEST ))
                     logger.finest( "Loading class: " + entryName );
-
-                jarEntryContents.put( entryName, content );
+                
+                JclJarEntry entry = new JclJarEntry();
+                entry.setResourceBytes(content);
+                jarEntryContents.put( entryName, entry );                
             }
         } catch (IOException e) {
             throw new JclException( e );

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -147,7 +148,7 @@ public class JarClassLoader extends AbstractClassLoader {
      * @param jarStream
      */
     public void add(InputStream jarStream) {
-        classpathResources.loadJar( jarStream );
+        classpathResources.loadJar( null, jarStream );
     }
 
     /**

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JclJarEntry.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JclJarEntry.java
@@ -1,0 +1,24 @@
+package org.xeustechnologies.jcl;
+
+public class JclJarEntry {
+  
+  private String baseUrl;
+  private byte[] resourceBytes;
+  
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+  
+  public void setBaseUrl(String argBaseUrl) {
+    baseUrl = argBaseUrl;
+  }
+  
+  public byte[] getResourceBytes() {
+    return resourceBytes;
+  }
+  
+  public void setResourceBytes(byte[] argResourceBytes) {
+    resourceBytes = argResourceBytes;
+  }
+
+}


### PR DESCRIPTION
Example code:
jarClassLoader.getResource("some-resources.xml");

This method has a high likelihood of return the wrong URL for the requested resource. The URL will reflect the last jar loaded by JarResources and not the actual jar where the resource is located.

This issue results from the fact that JarResources has a single baseUrl but is capable of loading resources from multiple jars. I have a change to track baseUrls of the resources in JarResource by changing from Map(String, byte[]) to Map(String, JclJarEntry) and will submit a patch.