### PR TITLE
Fix ConcurrentModificationException (issue #37)

### DIFF
--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -62,7 +62,7 @@ public class JarClassLoader extends AbstractClassLoader {
      * 
      */
     public void initialize() {
-        loaders.add( localLoader );
+        addLoader( localLoader );
     }
 
     /**


### PR DESCRIPTION
This addresses issue #37 -- this isn't really a Java 8 specific bug, but the different collection sort behavior makes it more obvious. The list of loaders isn't threadsafe and it's being mutated by lots of threads. You can get all kinds of unexpected behavior here in multithreaded environments (classloaders getting skipped, things loaded from the wrong place, etc). 

This change also moves the sort from the load* methods to the add* methods. I don't know why you'd want to resort on every access, that's a very expensive operation. I'd think you could sort on mutation instead. 

This does leave the slim chance, I guess, that a user has a custom subclass that is adding to the list directly (`loaders.add(...)`) and not sorting afterwards; their behavior might change. But there is an "addLoader" method available that behaves appropriately. 
Ideally, `loaders` could be made private to remove that possibility, but I didn't go that far.