### PR TITLE
add constructor  public JarClassLoader(final ClassLoader parent)

### DIFF
--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.jar.JarEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,6 +56,13 @@ public class JarClassLoader extends AbstractClassLoader {
         initialize();
     }
 
+    public JarClassLoader(final ClassLoader parent) {
+        super(parent);
+        classpathResources = new ClasspathResources();
+        classes = Collections.synchronizedMap( new HashMap<String, Class>() );
+        initialize();
+    }
+    
     /**
      * Some initialisations
      * 


### PR DESCRIPTION
add constructor  public JarClassLoader(final ClassLoader parent)
so that we we add parent classloader to JarClassLoader

fixed for Groovy Grape not work with JarClassLoader

```
@Grapes([
@Grab(group='org.tautua.markdownpapers', module='markdownpapers-core',
version='1.4.2')
])
import org.tautua.markdownpapers.*

println "classLoader1:"+Markdown.class.classLoader.getURLs();
```