### PR TITLE
Fix deadlock issue in #50

### DIFF
--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/JarClassLoader.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import org.xeustechnologies.jcl.exception.JclException;
 import org.xeustechnologies.jcl.exception.ResourceNotFoundException;
 
+import edu.emory.mathcs.backport.java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Reads the class bytes from jar files and other resources using
  * ClasspathResources
@@ -53,14 +55,16 @@ public class JarClassLoader extends AbstractClassLoader {
 
     public JarClassLoader() {
         classpathResources = new ClasspathResources();
-        classes = Collections.synchronizedMap( new HashMap<String, Class>() );
+        // classes = Collections.synchronizedMap( new HashMap<String, Class>() );
+        classes = new ConcurrentHashMap();
         initialize();
     }
 
     public JarClassLoader(final ClassLoader parent) {
         super(parent);
         classpathResources = new ClasspathResources();
-        classes = Collections.synchronizedMap( new HashMap<String, Class>() );
+        // classes = Collections.synchronizedMap( new HashMap<String, Class>() );
+        classes = new ConcurrentHashMap();
         initialize();
     }
 

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/SetList.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/SetList.java
@@ -1,0 +1,57 @@
+package org.xeustechnologies.jcl;
+
+import java.util.*;
+import java.io.Serializable;
+
+import edu.emory.mathcs.backport.java.util.concurrent.ConcurrentSkipListSet;
+
+public class SetList<E>
+        extends AbstractList<E>
+        implements List<E>, RandomAccess, Cloneable, Serializable {
+    protected final Set<E> underlying;
+    public SetList() {
+        // underlying = new ConcurrentSkipListSet<E>();
+        underlying = new ConcurrentSkipListSet();
+    }
+    public SetList(Set<E> other) {
+        underlying = other;
+    }
+    public E get(int index) {
+        Iterator<E> it = iterator();
+        for (int i = 0; i < index; i++) {
+            if (it.hasNext()) {
+                it.next();
+            } else {
+                throw new IndexOutOfBoundsException();
+            }
+        }
+        return it.next();
+    }
+    public int size() {
+        return underlying.size();
+    }
+    public E set(int index, E elem) {
+        if (add(elem)) {
+            return elem;
+        } else {
+            return null;
+        }
+    }
+    public boolean add(E elem) {
+        return underlying.add(elem);
+    }
+    public void add(int index, E elem) {
+        add(elem);
+    }
+    public E remove(int index) {
+        E elem = get(index);
+        if (underlying.remove(elem)) {
+            return elem;
+        } else {
+            return null;
+        }
+    }
+    public Iterator<E> iterator() {
+        return underlying.iterator();
+    }
+}

--- a/JCL2/core/src/main/java/org/xeustechnologies/jcl/context/JclContext.java
+++ b/JCL2/core/src/main/java/org/xeustechnologies/jcl/context/JclContext.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import org.xeustechnologies.jcl.JarClassLoader;
 import org.xeustechnologies.jcl.exception.JclContextException;
 
+import edu.emory.mathcs.backport.java.util.concurrent.ConcurrentHashMap;
+
 /**
  * JclContext holds all the JarClassLoader instances so that they can be
  * accessed from anywhere in the application.
@@ -32,8 +34,12 @@ import org.xeustechnologies.jcl.exception.JclContextException;
  * 
  */
 public class JclContext {
+    /*
     private static final Map<String, JarClassLoader> loaders = Collections
             .synchronizedMap( new HashMap<String, JarClassLoader>() );
+    private static final Map<String, JarClassLoader> loaders = new ConcurrentHashMap<String, JarClassLoader>();
+    */
+    private static final Map<String, JarClassLoader> loaders = new ConcurrentHashMap();
     public static final String DEFAULT_NAME = "jcl";
 
     public JclContext() {

--- a/JCL2/pom.xml
+++ b/JCL2/pom.xml
@@ -147,6 +147,11 @@
             <artifactId>object-cloner</artifactId>
             <version>0.1</version>
         </dependency>
+        <dependency>
+            <groupId>backport-util-concurrent</groupId>
+            <artifactId>backport-util-concurrent</artifactId>
+            <version>3.1</version>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
This addresses issue #50 

Main idea is from @fxgendrin in the issue #50 
> Need a new release with following modification in AbstractClassLoader (as suggested in comment, but need to be compatible only with java 1.6, alternative is to duplicate ConcurrentSkipListSet into the project)
`protected final Set<ProxyClassLoader> loaders = new ConcurrentSkipListSet<ProxyClassLoader>();`

Besides the original proposal, there are some minor tweaks
* Used [backport](http://backport-jsr166.sourceforge.net/) implementation of `java.util.concurrent` in order to support java 1.5+, while some of the required classes are available since 1.6
* To prevent `loaders` becoming `Set` from `List`, introduced thin wrapper(`SetList`) that wraps `Set` as `List`
* Removed `synchronized` related codes/blocks because now `java.util.concurrent` handles the concurrent access/modification.

Checked that all existing tests are passing. But cannot think of a way to test properly that this really resolves the problem at hand.

Actually, my first choice was to ignore java 1.5+ support and just to use `java.util.concurrent` package. I tried that in my use case and it seemed to work as I expected.